### PR TITLE
Refactor airflow env merge

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 x-airflow-common: &airflow-common
   image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.7.3}
-  environment:
+  environment: &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres:5432/airflow
@@ -57,6 +57,7 @@ services:
                  --role Admin \
                  --email admin@example.com'
     environment:
+      <<: *airflow-common-env
       _AIRFLOW_WWW_USER_USERNAME: admin
       _AIRFLOW_WWW_USER_PASSWORD: admin
 


### PR DESCRIPTION
## Summary
- create `airflow-common-env` anchor for docker-compose
- reuse this anchor in the `airflow-init` service to ensure DB variables are set

## Testing
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688398e17fa08330b234717cced09eea